### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,7 @@
         remainingLoadCount || setTimeout(loadHandler);
     }
 
-    (requirejs = require = req).config = function (conf) { // eslint-disable-line
+    (requirejs = require = req)['config'] = function (conf) { // eslint-disable-line
         baseUrl = conf.baseUrl || baseUrl;
     };
 
@@ -199,6 +199,6 @@
         }
     }
 
-    def.amd = loaded;
-    define = def; // eslint-disable-line
+    def['amd'] = loaded;
+    window['define'] = def; // eslint-disable-line
 }());


### PR DESCRIPTION
After those changes, the test suite still passes after google closure advanced compilation (http://www.closure-compiler.appspot.com/home#code)

GC-A: 734 bytes gzipped (1.2KB uncompressed)
Uglifyjs: 1063 bytes gzipped (2.7KB uncompressed)

Please test it yourself. I only did a basic replacement of index.js with the compiled output and ran `npm test`.

Would also be interesting to analyse, what optimizations were performed by closure
